### PR TITLE
Set default response writer status to 200.

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -28,7 +28,11 @@ type beforeFunc func(ResponseWriter)
 
 // NewResponseWriter creates a ResponseWriter that wraps an http.ResponseWriter
 func NewResponseWriter(rw http.ResponseWriter) ResponseWriter {
-	return &responseWriter{rw, 0, 0, nil}
+	return &responseWriter{
+		ResponseWriter: rw,
+		status:         http.StatusOK,
+		size:           0,
+		beforeFuncs:    nil}
 }
 
 type responseWriter struct {


### PR DESCRIPTION
In the case, where the underlying handler does not write to the response writer, the negroni
response writer would report status 0 (instead of 200, as expected).
